### PR TITLE
add function for more control on cpuStream

### DIFF
--- a/lib/cpu_reader.dart
+++ b/lib/cpu_reader.dart
@@ -14,10 +14,19 @@ class CpuReader {
   static HashMap<int, MinMaxFrequency<int>> _minMaxFrequencies =
       HashMap<int, MinMaxFrequency<int>>();
 
-  /// [CpuInfo] stream with set [interval] value as [Duration]
+  /// [CpuInfo] stream with set [interval] in milliseconds
   static Stream<CpuInfo> cpuStream(int interval) async* {
     while (true) {
       await Future.delayed(Duration(milliseconds: interval));
+      CpuInfo info = await CpuReader.cpuInfo;
+      yield info;
+    }
+  }
+
+  ///  [CpuInfo] stream with set [interval] duration
+  static Stream<CpuInfo> cpuStream(Duration interval) async* {
+    while(true) {
+      await Future.delayed(interval);
       CpuInfo info = await CpuReader.cpuInfo;
       yield info;
     }


### PR DESCRIPTION
Instead of just milliseconds as the `int interval` which is very vague without reading source code, this PR introduces a new function with the `Duration` class for more customized control.